### PR TITLE
Pin rules_go to 0.12.* release for now

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -31,8 +31,8 @@ http_archive(
 # === Go Integration ===
 http_archive(
     name = "io_bazel_rules_go",
-    strip_prefix = "rules_go-master",
-    urls = ["https://github.com/bazelbuild/rules_go/archive/master.zip"],
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.12.1/rules_go-0.12.1.tar.gz",
+    sha256 = "8b68d0630d63d95dacc0016c3bb4b76154fe34fca93efd65d1c366de3fcb4294",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")


### PR DESCRIPTION
Build is failing otherwise, something to do with HEAD of rules_go being 0.13.* which isn't compatible with our use. Figuring out why and upgrading to 0.13.* is left as an exercise for the reader.